### PR TITLE
[#33-Issue] Add options to import cmd to import tasks from a json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A tasks manager for those who like work from shell.
 ![PyPI - Version](https://img.shields.io/pypi/v/dailytasks?style=for-the-badge&label=Lastest%20version&color=008B8B&link=https%3A%2F%2Fpypi.org%2Fproject%2Fdailytasks%2F)
 ![GitHub issue custom search in repo](https://img.shields.io/github/issues-search/LuisanaMTDev/dailytasks?query=is%3Aopen&style=for-the-badge&label=Open%20issues&color=008B8B&link=https%3A%2F%2Fgithub.com%2FLuisanaMTDev%2Fdailytasks%2Fissues%3Fq%3Dis%253Aissue%2Bis%253Aopen)
 
+
+
 ## Installation ##
 **Requirements:**
 - Python >= 3.11
@@ -25,6 +27,20 @@ A tasks manager for those who like work from shell.
 
    **This is because when you update the CLI, data folder ([data_files](./daily_tasks/data_files/)) is overwritten and all your data deleted.**
    
+## How to add tasks from a json file ##
+Execute `dailytasks import --help` to get information about import cmd options.
+
+import options:
+- Normal:
+    `dailytasks import -p C:\where\you\export\tasks\are`
+- Personalized (A better name is welcome):
+    `dailytasks import -a -f your_json_file_name -d key_that_contains_the_descriptions -p C:\where\you\json\file\is`
+
+    - `-a`: Activate this option.
+    - `-f`: To pass name of your json file.
+    - `-d`: The text you want as description should be in a object, in a key-value pair, to this option you will pass key of that key-value pair.
+    - `-p`: To pass path where you json file is.
+
 ## Testing ##
 
 Running tests locally:

--- a/daily_tasks/commands/info_commands.py
+++ b/daily_tasks/commands/info_commands.py
@@ -2,6 +2,7 @@ from os.path import join
 import json
 import click as ck
 from daily_tasks.commands import utilities
+from daily_tasks.commands.main_commands import add
 
 
 @ck.command
@@ -21,22 +22,52 @@ def export_tasks(export_path):
 
 @ck.command
 @ck.option(
+    '-a', '--add-tasks',
+    is_flag=True,
+    required=False,
+    help="To add tasks from a json file."
+)
+@ck.option(
+    '-f', '--file-name',
+    required=False,
+    help="Name of the json file where tasks you want add are."
+)
+@ck.option(
+    '-d', '--description-key',
+    required=False,
+    help="Key that contains the descriptions for your tasks."
+)
+@ck.option(
     '-p', '--import-path',
     type=ck.Path(exists=True, dir_okay=True, resolve_path=True),
     required=True,
-    help=f'Directory/Folder where your {utilities.EXPORTED_TASKS_FILE} is.'
+    help=f'Directory/Folder where your {utilities.EXPORTED_TASKS_FILE} is, \n Or where your json file with tasks that you want add is (to pass this json file use -a flag).'
 )
-def import_tasks(import_path):
+@ck.pass_context
+def import_tasks(ctx, import_path, file_name: str | None , description_key: str | None, add_tasks=False):
     """Import your tasks."""
 
     with open(utilities.TASKS_FILE_PATH, 'r', encoding='utf-8') as tasks_file:
         existing_tasks = json.load(tasks_file)
 
-    with open(join(import_path, utilities.EXPORTED_TASKS_FILE), 'r', encoding='utf-8') as imported_tasks_file:
-        tasks = json.load(imported_tasks_file)
+    if add_tasks is False:
+        with open(join(import_path, utilities.EXPORTED_TASKS_FILE), 'r', encoding='utf-8') as imported_tasks_file:
+            tasks = json.load(imported_tasks_file)
 
-    for task in tasks:
-        existing_tasks.append(task)
-        
-    with open(utilities.TASKS_FILE_PATH, 'w', encoding='utf-8') as tasks_file:
-        json.dump(existing_tasks, tasks_file, indent=2)
+        for task in tasks:
+            existing_tasks.append(task)
+
+        with open(utilities.TASKS_FILE_PATH, 'w', encoding='utf-8') as tasks_file:
+            json.dump(existing_tasks, tasks_file, indent=2)
+    else:
+        with open(join(import_path, f'{file_name}.json'), 'r', encoding='utf-8') as new_tasks_file:
+            new_tasks = json.load(new_tasks_file)
+
+        new_tasks_descriptions = []
+
+        for new_task in new_tasks:
+            new_tasks_descriptions.append(new_task[description_key])
+
+        for new_task_description in new_tasks_descriptions:
+            ctx.invoke(add, description=new_task_description)
+            

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dailytasks"
-version = "2.1.3"
+version = "2.2.0"
 authors = [{name = "LuisanaMTDev", email = "luisanamartineztorres25@gmail.com"}]
 description = "A tasks manager for those who like work from shell."
 readme = "README.md"


### PR DESCRIPTION
This PR is for add options to import cmd to import tasks from a json file.

Tasks: 
- [x] Add options to import cmd.
- [ ] Explain how this feature works.